### PR TITLE
Typo corrected

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   "homepage": "https://github.com/BreadMaker/semantic-ui-daterangepicker",
   "engines": {
     "node": "0.10.32",
-    "nmp": "1.4.28"
+    "npm": "1.4.28"
   },
   "dependencies": {
     "jquery": "^1.10",


### PR DESCRIPTION
Stumbled upon that type when yarn threw an error:

> error semantic-ui-daterangepicker@1.3.21: The engine "node" is incompatible with this module. Expected version "0.10.32".
> warning semantic-ui-daterangepicker@1.3.21: The engine "nmp" appears to be invalid.
> error Found incompatible module